### PR TITLE
issue #18: fix alternate urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ index/
 
 # Pickle files
 *.pkl
+*.pickle
 
 # OS specific
 .DS_Store

--- a/notebooks/issue18-url-alternates.ipynb
+++ b/notebooks/issue18-url-alternates.ipynb
@@ -1,0 +1,422 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Issue [#18](https://github.com/ai-cfia/llamaindex-db/issues/18)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from llama_index.core import VectorStoreIndex\n",
+    "from llama_index.vector_stores.postgres import PGVectorStore\n",
+    "from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding\n",
+    "from llama_index.llms.azure_openai import AzureOpenAI\n",
+    "from llama_index.core import Settings\n",
+    "from llama_index.core.schema import NodeWithScore, TextNode\n",
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "import psycopg\n",
+    "from psycopg.rows import dict_row\n",
+    "from pprint import pprint\n",
+    "import pickle\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def save_to_pickle(data, filename):\n",
+    "    with open(filename, \"wb\") as file:\n",
+    "        pickle.dump(data, file)\n",
+    "\n",
+    "\n",
+    "def load_from_pickle(filename):\n",
+    "    with open(filename, \"rb\") as file:\n",
+    "        return pickle.load(file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup LLM and Embed Model\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = AzureOpenAI(\n",
+    "    model=\"gpt-4\",\n",
+    "    deployment_name=\"ailab-llm\",\n",
+    "    api_key=os.getenv(\"API_KEY\"),\n",
+    "    azure_endpoint=os.getenv(\"AZURE_ENDPOINT\"),\n",
+    "    api_version=os.getenv(\"API_VERSION\"),\n",
+    ")\n",
+    "\n",
+    "embed_model = AzureOpenAIEmbedding(\n",
+    "    model=\"text-embedding-ada-002\",\n",
+    "    deployment_name=\"ada\",\n",
+    "    api_key=os.getenv(\"API_KEY\"),\n",
+    "    azure_endpoint=os.getenv(\"AZURE_ENDPOINT\"),\n",
+    "    api_version=os.getenv(\"API_VERSION\"),\n",
+    ")\n",
+    "\n",
+    "Settings.llm = llm\n",
+    "Settings.embed_model = embed_model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Variables\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "database = os.getenv(\"DB_NAME\")\n",
+    "host = os.getenv(\"DB_HOST\")\n",
+    "password = os.getenv(\"DB_PASSWORD\")\n",
+    "port = os.getenv(\"DB_PORT\")\n",
+    "user = os.getenv(\"DB_USER\")\n",
+    "llamaindex_db = \"llamaindex_db_legacy\"\n",
+    "llamaindex_schema = \"v_0_0_1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Observed problem\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Find urls alternates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn_string = (\n",
+    "    f\"dbname={database} \"\n",
+    "    f\"user={user} \"\n",
+    "    f\"password={password} \"\n",
+    "    f\"host={host} \"\n",
+    "    f\"port={port}\"\n",
+    ")\n",
+    "query = \"\"\"\n",
+    "    SELECT c1.url, c2.url\n",
+    "    FROM louis_v005.crawl AS c1\n",
+    "    JOIN louis_v005.crawl AS c2\n",
+    "    ON (\n",
+    "        REGEXP_MATCH(c1.url, '.*/([a-z]{3})/([0-9]+)/([0-9]+)$') = \n",
+    "        REGEXP_MATCH(c2.url, '.*/([a-z]{3})/([0-9]+)/([0-9]+)$')\n",
+    "        AND c1.url < c2.url\n",
+    "    );\n",
+    "    \"\"\"\n",
+    "with psycopg.connect(conn_string) as conn:\n",
+    "    with conn.cursor() as cur:\n",
+    "        url_alternates = cur.execute(query).fetchall()\n",
+    "        \n",
+    "save_to_pickle(url_alternates, \"url_alternates.pickle\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('https://inspection.canada.ca/about-cfia/media-relations/eng/1299073792503/1299076004509',\n",
+      "  'https://inspection.canada.ca/about-cfia/newsroom/eng/1299073792503/1299076004509'),\n",
+      " ('https://inspection.canada.ca/about-cfia/media-relations/food-recall-warnings/eng/1299076382077/1299076493846',\n",
+      "  'https://inspection.canada.ca/about-cfia/newsroom/food-recall-warnings/eng/1299076382077/1299076493846'),\n",
+      " ('https://inspection.canada.ca/about-cfia/acts-and-regulations/recent-regulatory-initiatives-and-notices-of-inten/eng/1299849033508/1299849093611',\n",
+      "  'https://inspection.canada.ca/about-cfia/acts-and-regulations/regulatory-initiatives-notices-of-intent/eng/1299849033508/1299849093611'),\n",
+      " ('https://inspection.canada.ca/about-cfia/media-relations/stay-connected/eng/1299856061207/1299856119191',\n",
+      "  'https://inspection.canada.ca/about-cfia/newsroom/stay-connected/eng/1299856061207/1299856119191'),\n",
+      " ('https://inspection.canada.ca/animal-health/humane-transport/eng/1300460032193/1300460096845',\n",
+      "  'https://inspection.canada.ca/animal-health/terrestrial-animals/humane-transport/eng/1300460032193/1300460096845')]\n",
+      "len(url_alternates) 298\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(url_alternates[0:5])\n",
+    "print(\"len(url_alternates)\", len(url_alternates))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Urls that don't follow the same pattern"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn_string = (\n",
+    "    f\"dbname={database} \"\n",
+    "    f\"user={user} \"\n",
+    "    f\"password={password} \"\n",
+    "    f\"host={host} \"\n",
+    "    f\"port={port}\"\n",
+    ")\n",
+    "query = \"\"\"\n",
+    "    SELECT c.url\n",
+    "    FROM louis_v005.crawl AS c\n",
+    "    WHERE NOT c.url ~ '.*/([a-z]{3})/([0-9]+)/([0-9]+)$';\n",
+    "    \"\"\"\n",
+    "with psycopg.connect(conn_string) as conn:\n",
+    "    with conn.cursor() as cur:\n",
+    "        fringe_urls = cur.execute(query).fetchall()\n",
+    "        \n",
+    "save_to_pickle(fringe_urls, \"fringe_urls.pickle\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('https://inspection.canada.ca/about-cfia/transparency/corporate-management-reporting/reports-to-parliament/financial-reporting/quarter-ended-december-31-2019/eng//1582828285258/1582828285769',),\n",
+      " ('https://inspection.canada.ca/preventive-controls/cleaning-and-sanitation-program/eng//1511374381399/1528206247934',),\n",
+      " ('https://inspection.canada.ca/food-safety-for-industry/archived-food-guidance/meat-and-poultry-products/manual-of-procedures/directives-2017/2017-46/eng//1501247449418/1501247566311',),\n",
+      " ('https://inspection.canada.ca/about-cfia/contact-a-cfia-office-by-telephone/eng//1313255382836/1313256130232',),\n",
+      " ('https://inspection.canada.ca/food-safety-for-industry/toolkit-for-food-businesses/food-notices-for-industry/eng//1632510003942/1632510004676',)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(fringe_urls)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Consequences\n",
+    "\n",
+    "- Embeddings are generated in doubles for the same page.\n",
+    "- Duplicated search results\n",
+    "- Slightly degraded search accuracy as tested by our `api-test` tool"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fix\n",
+    "\n",
+    "- create a new view `unique_documents` similar to the `documents` view but built using unique entries in the `crawl` table, with a new field `url_id` (Ex: `/eng/1299073792503/1299076004509`)\n",
+    "\n",
+    "The sql code for this would look like:\n",
+    "\n",
+    "```sql\n",
+    "CREATE OR REPLACE VIEW louis_v005.unique_documents AS\n",
+    "WITH extracted_ids AS (\n",
+    "    SELECT\n",
+    "        id,\n",
+    "        url,\n",
+    "        substring(url, '/[a-z]{3}/[0-9]+/[0-9]+$') AS url_id,\n",
+    "        lang,\n",
+    "        title,\n",
+    "        md5hash,\n",
+    "        last_updated\n",
+    "    FROM louis_v005.crawl\n",
+    "),\n",
+    "unique_crawls AS (\n",
+    "    SELECT DISTINCT ON (url_id)\n",
+    "        id,\n",
+    "        url,\n",
+    "        url_id,\n",
+    "        lang,\n",
+    "        title,\n",
+    "        md5hash,\n",
+    "        last_updated\n",
+    "    FROM extracted_ids\n",
+    ")\n",
+    "SELECT \n",
+    "    crawl.id,\n",
+    "    chunk.id AS chunk_id,\n",
+    "    crawl.url,\n",
+    "    crawl.url_id,\n",
+    "    crawl.lang,\n",
+    "    html_content.content AS html_content,\n",
+    "    crawl.title,\n",
+    "    chunk.title AS subtitle,\n",
+    "    chunk.text_content AS content,\n",
+    "    embedding.embedding,\n",
+    "    cardinality(token.tokens) AS tokens_count,\n",
+    "    crawl.last_updated,\n",
+    "    scoring.score\n",
+    "FROM \n",
+    "    unique_crawls AS crawl\n",
+    "JOIN louis_v005.html_content ON crawl.md5hash = html_content.md5hash\n",
+    "JOIN louis_v005.html_content_to_chunk ON html_content.md5hash = html_content_to_chunk.md5hash\n",
+    "JOIN louis_v005.chunk ON html_content_to_chunk.chunk_id = chunk.id\n",
+    "JOIN louis_v005.token ON chunk.id = token.chunk_id\n",
+    "JOIN louis_v005.ada_002 embedding ON token.id = embedding.token_id\n",
+    "JOIN louis_v005.scoring ON crawl.id = scoring.entity_id;\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No duplicates found. View created successfully.\n"
+     ]
+    }
+   ],
+   "source": [
+    "conn_string = (\n",
+    "    f\"dbname={database} \"\n",
+    "    f\"user={user} \"\n",
+    "    f\"password={password} \"\n",
+    "    f\"host={host} \"\n",
+    "    f\"port={port}\"\n",
+    ")\n",
+    "\n",
+    "create_view_query = \"\"\"\n",
+    "CREATE OR REPLACE VIEW louis_v005.unique_documents AS\n",
+    "WITH extracted_ids AS (\n",
+    "    SELECT\n",
+    "        id,\n",
+    "        url,\n",
+    "        substring(url, '/[a-z]{3}/[0-9]+/[0-9]+$') AS url_id,\n",
+    "        lang,\n",
+    "        title,\n",
+    "        md5hash,\n",
+    "        last_updated\n",
+    "    FROM louis_v005.crawl\n",
+    "),\n",
+    "unique_crawls AS (\n",
+    "    SELECT DISTINCT ON (url_id)\n",
+    "        id,\n",
+    "        url,\n",
+    "        url_id,\n",
+    "        lang,\n",
+    "        title,\n",
+    "        md5hash,\n",
+    "        last_updated\n",
+    "    FROM extracted_ids\n",
+    ")\n",
+    "SELECT \n",
+    "    crawl.id,\n",
+    "    chunk.id AS chunk_id,\n",
+    "    crawl.url,\n",
+    "    crawl.url_id,\n",
+    "    crawl.lang,\n",
+    "    html_content.content AS html_content,\n",
+    "    crawl.title,\n",
+    "    chunk.title AS subtitle,\n",
+    "    chunk.text_content AS content,\n",
+    "    embedding.embedding,\n",
+    "    cardinality(token.tokens) AS tokens_count,\n",
+    "    crawl.last_updated,\n",
+    "    scoring.score\n",
+    "FROM \n",
+    "    unique_crawls AS crawl\n",
+    "JOIN louis_v005.html_content ON crawl.md5hash = html_content.md5hash\n",
+    "JOIN louis_v005.html_content_to_chunk ON html_content.md5hash = html_content_to_chunk.md5hash\n",
+    "JOIN louis_v005.chunk ON html_content_to_chunk.chunk_id = chunk.id\n",
+    "JOIN louis_v005.token ON chunk.id = token.chunk_id\n",
+    "JOIN louis_v005.ada_002 embedding ON token.id = embedding.token_id\n",
+    "JOIN louis_v005.scoring ON crawl.id = scoring.entity_id;\n",
+    "\"\"\"\n",
+    "\n",
+    "check_duplicates_query = \"\"\"\n",
+    "SELECT url_id, COUNT(DISTINCT url) AS unique_url_count\n",
+    "FROM louis_v005.unique_documents\n",
+    "GROUP BY url_id\n",
+    "HAVING COUNT(DISTINCT url) > 1;\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "with psycopg.connect(conn_string) as conn:\n",
+    "    with conn.cursor() as cur:\n",
+    "        cur.execute(create_view_query)\n",
+    "        duplicates = cur.execute(check_duplicates_query).fetchall()\n",
+    "        if duplicates:\n",
+    "            print(\"Found duplicate url_id values:\", duplicates)\n",
+    "            conn.rollback()\n",
+    "        else:\n",
+    "            print(\"No duplicates found. View created successfully.\")\n",
+    "            conn.commit()\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llamaindex-db",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Closes #18
- [x] created a view `unique_documents` in the db where all referenced pages are unique. Check [notebook](https://github.com/ai-cfia/llamaindex-db/blob/3ee6800e848b24f433145e9bb94419ab27ca85e6/notebooks/issue18-url-alternates.ipynb)